### PR TITLE
Debug option

### DIFF
--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -272,6 +272,13 @@ export default class Cli {
       spinner.succeed(`Started Docker container: ${this.startedID.substring(0, 12)}`);
       spinner = ora.start(`Health check`);
     }
+
+    if (options.debug) {
+      const logStream = await this._run.getLogStream()
+      logStream.pipe(process.stdout)
+    }
+
+
     await new Promise((res) => setTimeout(res, 1000)); // wait for the container to start
     if (!await this._run.isRunning()) { // 2. health check
       if (options.raw) {
@@ -338,6 +345,12 @@ export default class Cli {
       process.exit(1);
     }
     this._subscribe = new Subscribe(this.microservice, argsObj, this._run);
+
+    if (options.debug) {
+      const logStream = await this._run.getLogStream()
+      logStream.pipe(process.stdout)
+    }
+    
     try {
       await this._subscribe.go(action, event);
       spinner.succeed(`Subscribed to event: \`${event}\` data will be posted to this terminal window when appropriate`);

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -30,6 +30,7 @@ program
   .option('-i --image <i>', 'The name of the image to spin up the microservice, if not provided a fresh image will be build based of the `Dockerfile`')
   .option('-a --args <a>', 'Arguments to be passed to the command, must be of the form `key="val"`', appender(), [])
   .option('-e --envs <e>', 'Environment variables to be passed to run environment, must be of the form `key="val"`', appender(), [])
+  .option('-d --debug', 'Shows the output of the docker container.')
   .option('-r --raw', 'All logging is suppressed expect for the output of the action.')
   .description('Run actions defined in your `microservice.yml`. Must be ran in a directory with a `Dockerfile` and a `microservice.yml`')
   .action(async (action, options) => {

--- a/src/commands/run/Run.ts
+++ b/src/commands/run/Run.ts
@@ -2,7 +2,7 @@ import * as utils from '../../utils';
 import * as verify from '../../verify';
 import Action from '../../models/Action';
 import Microservice from '../../models/Microservice';
-import { Readable, Writable, Stream, Duplex } from 'stream'
+import { Stream } from 'stream'
 
 
 /**
@@ -164,79 +164,18 @@ export default abstract class Run {
       this.exposedPorts[`${neededPorts[i]}/tcp`] = {};
       this.portBindings[`${neededPorts[i]}/tcp`] = [{HostPort: openPorts[i].toString()}];
     }
-    // console.log(this.microservice.lifecycle.startup)
-    // console.log(this.microservice.lifecycle.startup)
-
-    console.log(this.microservice.lifecycle.startup)
 
     const container = await utils.docker.createContainer({
       Image: this.dockerImage,
       Entrypoint: this.microservice.lifecycle.startup,
       Env: this.formatEnvironmentVariables(),
-      AttachStdin: true,
-      Tty: true,
-      OpenStdin: true,
       ExposedPorts: this.exposedPorts,
       HostConfig: {
         PortBindings: this.portBindings,
-        //LogConfig: {Type: "none", Config: {}}
       },
     });
 
     await container.start();
-
-    // logs.pipe(process.stdout);
-    console.log('~~~~~~~~~~~')
-    try {
-      const logs = await container.logs({
-        follow: true,
-        stdout: true,
-        sterr: true,
-        timestamps: true,
-      })
-      // console.log(logs instanceof Stream)
-      // console.log(logs instanceof Readable)
-      // console.log(logs instanceof Writable)
-
-      // console.log(logs)
-      // logs.push("PRINT STREAM TO STDOUT :::::: ")
-      logs.pipe(process.stdout)
-      await new Promise(function (resolve, reject) {
-        setTimeout(resolve, 4000);
-    });
-
-      // container.modem.demuxStream(logs, process.stdout, process.stdout);
-      // stream.on('end', function(){
-      //   logStream.end('!stop!');
-      // });
-      // logs.pipe( process.stdout )
-      // logs.on('start', function() {
-      //   console.log('starting');
-      // });
-      // logs.on('end', function() {
-      //   console.log('finished');
-      // });
-      // var logStream = new Duplex({
-      //   read(size) {
-      //     // ...
-      //   },
-      //   write(chunk, encoding, callback) {
-      //     // ...
-      //   }
-      //   )}
-      // logStream.on('pipe', function(chunk){
-      //   console.log(chunk.toString('utf8'));
-
-      // });
-      // container.modem.demuxStream(logs, logStream, logStream);
-      // stream.on('end', function(){
-      //   logStream.end('!stop!');
-      // });
-    } catch(e) {
-      console.error(e)
-    }
-    // console.log('~~~~~~~~~~~')
-
     this.containerID = container.$subject.id;
     return this.containerID;
   }
@@ -263,7 +202,23 @@ export default abstract class Run {
   }
 
   /**
-   * Gets the Docker logs.
+   * Gets the Docker logs as stream.
+   *
+   * return {Stream} The Docker logs
+   */
+  public async getLogStream(): Promise<Stream> {
+    const container = utils.docker.getContainer(this.containerID);
+    const logs = container.logs({
+      follow: true,
+      stdout: true,
+      sterr: true,
+      timestamps: false,
+    })
+    return logs
+  }
+
+  /**
+   * Gets the Docker error logs as string.
    *
    * return {String} The Docker logs
    */


### PR DESCRIPTION
--debug option attaches to docker logs (application output) on startup. It was useful to me for debugging.

But the visual appearance needs some modification, since the stream is merged basically with the other stuff.

ie:
```
Successfully tagged omg/l1vzzxjzl2nocmlzl0nvzguvu3rvcnlzy3jpchqvbwljcm9zzxj2awnlcy9pbwfnzv9tywdpy2tfbwljcm9zzxj2awnl:latest
✔ Built Docker image with name: omg/l1vzzxjzl2nocmlzl0nvzguvu3rvcnlzy3jpchqvbwljcm9zzxj2awnlcy9pbwfnzv9tywdpy2tfbwljcm9zzxj2awnl
✔ Started Docker container: 95d0203cc709
⠸ Health check�I am the Phoenix App and I am working!10:57:08.125 [info] Running ImageMagickMicroserviceWeb.Endpoint with cowboy 2.6.3 at :::8000 (http)
X10:57:08.125 [info] Access ImageMagickMicroserviceWeb.Endpoint at http://localhost:8000
✔ Health check passed
✔ Ran action: `image` with output: "Does this work"
⠋ Stopping Docker container: 95d0203cc709C10:57:10.202 request_id=FalFvnb1JOOnGYIAAAAB [info] GET /api/image
F10:57:10.202 request_id=FalFvnb1JOOnGYIAAAAB [info] Sent 200 in 84µs
✔ Stopped Docker container: 95d0203cc709
```