### PR TITLE
Fix hostname mapping for linux event callbacks

### DIFF
--- a/packages/cli/src/services/action/executeEventsAction.ts
+++ b/packages/cli/src/services/action/executeEventsAction.ts
@@ -56,10 +56,7 @@ export default async function executeEventsAction({
   })
 
   const httpServerPort = await getPort()
-  const httpServerSocket = httpServer.listen({
-    port: httpServerPort,
-    hostname: '127.0.0.1',
-  })
+  const httpServerSocket = httpServer.listen(httpServerPort, '0.0.0.0')
   const disposable = new Disposable(() => {
     httpServerSocket.close()
   })
@@ -74,7 +71,7 @@ export default async function executeEventsAction({
   const subscribePath = event.http.subscribe.path
   const subscribeMethod = event.http.subscribe.method
   const inspectionResult = await daemon.inspectContainer()
-  const dockerHostIp = inspectionResult.NetworkSettings.IPAddress
+  const dockerHostIp = inspectionResult.NetworkSettings.Gateway
   const hostIp = SHOULD_USE_NAMED ? 'host.docker.internal' : dockerHostIp
 
   // Subscribe to events

--- a/tests/regression/test.sh
+++ b/tests/regression/test.sh
@@ -4,7 +4,7 @@ set -e  # Exit abruptly on any error.
 
 source functions.sh
 
-OMS_PATH=`get_oms_path`
+export OMS_PATH=`get_oms_path`
 
 WORK_DIR=`mktemp -d`
 echo "Working in ${WORK_DIR}"


### PR DESCRIPTION
We were using the IPAddress of the container itself instead of connecting to the gateway, which is the host we're running our listener on.

Also updates the listener to bind on all IPs.